### PR TITLE
US-15 Implement appointment creation endpoint

### DIFF
--- a/app/api/endpoints/appointments.py
+++ b/app/api/endpoints/appointments.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends, status
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from typing import List
+
+from app.db.session import get_database
+from app.schemas.user import UserResponse
+from app.schemas.appointment import AppointmentCreate, AppointmentResponse
+from app.crud import crud_appointment
+from app.core.security import get_current_user
+
+router = APIRouter()
+
+@router.post("/", response_model=AppointmentResponse, status_code=status.HTTP_201_CREATED)
+async def create_appointment(
+    appointment_in: AppointmentCreate,
+    db: AsyncIOMotorDatabase = Depends(get_database),
+    current_user: UserResponse = Depends(get_current_user)
+):
+    """
+    Crea una nueva cita.
+    """
+    appointment = await crud_appointment.create(
+        db=db,
+        business_id=appointment_in.business_id,
+        user_id=current_user.id,
+        appointment_time=appointment_in.appointment_time
+    )
+    
+    return AppointmentResponse.model_validate(appointment)

--- a/app/crud/crud_appointment.py
+++ b/app/crud/crud_appointment.py
@@ -1,0 +1,17 @@
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from bson import ObjectId
+from datetime import datetime, timedelta
+
+async def create(db: AsyncIOMotorDatabase, *, business_id: str, user_id: str, appointment_time: datetime):
+    """Crea un nuevo documento de cita en la base de datos."""
+    appointment_doc = {
+        "business_id": ObjectId(business_id),
+        "user_id": ObjectId(user_id),
+        "appointment_time": appointment_time,
+        "status": "confirmed",
+        "created_at": datetime.utcnow()
+    }
+    
+    result = await db["appointments"].insert_one(appointment_doc)
+    created_appointment = await db["appointments"].find_one({"_id": result.inserted_id})
+    return created_appointment

--- a/app/schemas/appointment.py
+++ b/app/schemas/appointment.py
@@ -1,0 +1,29 @@
+
+from pydantic import BaseModel, Field, field_validator
+from datetime import datetime
+from typing import Any
+from bson import ObjectId
+from .utils import PyObjectId
+
+class AppointmentCreate(BaseModel):
+    business_id: str
+    appointment_time: datetime
+
+class AppointmentResponse(BaseModel):
+    id: str = Field(..., alias="_id")
+    user_id: str
+    business_id: str 
+    appointment_time: datetime
+
+    @field_validator("id", "user_id", "business_id", mode='before') 
+    @classmethod
+    def convert_objectid_to_str(cls, v: Any) -> str:
+        if isinstance(v, ObjectId):
+            return str(v)
+        return v
+    
+    class Config:
+        from_attributes = True
+        populate_by_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}


### PR DESCRIPTION
A better restructuration of the appointment creation process is implemented. The logic for the POST /api/appointments/ endpoint has been refactored to improve how appointment details are saved to the database, replacing the previous implementation.

Tests confirming that the endpoint works and the API runs correctly: 

<img width="921" height="402" alt="image" src="https://github.com/user-attachments/assets/9f295447-1777-4b1e-ad36-00a76ee25640" />
<img width="921" height="258" alt="image" src="https://github.com/user-attachments/assets/5d7d28ee-00fb-4ff7-8e4b-8c6589aa0c68" />
